### PR TITLE
Added script to verify that the hostcert and hostkey match and are valid

### DIFF
--- a/files/verify_certificate
+++ b/files/verify_certificate
@@ -1,0 +1,32 @@
+#!/bin/bash
+# run with any parameter to get verbose debugging
+
+# Ulf Tigerstedt <ulf.tigerstedt@csc.fi> 2017
+
+KEYMOD=`openssl rsa -noout -modulus -in /etc/grid-security/hostkey.pem`
+CERTMOD=`openssl x509 -noout -modulus -in /etc/grid-security/hostcert.pem`
+VERIFY=`openssl verify -CApath /etc/grid-security/certificates -purpose sslserver /etc/grid-security/hostcert.pem`
+
+if [ "$KEYMOD" = "$CERTMOD" ]; then 
+	if [ ! -z $1 ]; then
+		echo Modulus of key and cert matches
+	fi
+else
+	if [ ! -z $1 ]; then
+		echo Modulus of key and cert mismatches
+	fi
+	exit 1
+fi 
+
+if [[ "$VERIFY" =~ "error" ]]; then
+	if [ ! -z $1 ]; then
+		echo Verification of hostcert failed
+                echo $VERIFY
+	fi
+	exit 1
+else
+	if [ ! -z $1 ]; then
+		echo Verification of hostcert succeeded
+                echo $VERIFY
+	fi
+fi

--- a/tasks/step2.yml
+++ b/tasks/step2.yml
@@ -102,3 +102,8 @@
   copy: src=files/certificates/hostcert.pem dest=/etc/grid-security/ owner=root mode=0644
   when: hostcert.stat.exists
   notify: restart_arc_frontend_services
+
+- name: verify certificate and hostkey
+  script: files/verify_certificate
+
+


### PR DESCRIPTION
Added a script to verify two things:
1) verify that the hostcert and hostkey on the gridnode belong together (having a matching modulus)
2) verify that "openssl verify" passes. Cert is valid and issued by a valid CA.

Tested on io